### PR TITLE
docs: RFC-0009 Server Action API 설계 및 타입 정합성 정리

### DIFF
--- a/docs/decisions/0006-domain-naming-conventions.md
+++ b/docs/decisions/0006-domain-naming-conventions.md
@@ -89,8 +89,8 @@ export const CATEGORY_GROUP = {
 | `Card` (schemes.ts) | 삭제 | Word + Translation을 담는 레거시 타입, 도메인의 Card와 혼동 |
 | `CategoryType` | 삭제 | `CATEGORY_GROUP` 상수로 대체 |
 | `StudyInfo` | `CardState` | ts-fsrs `Card`의 camelCase 래퍼. `StudyInfo`는 모호하므로 도메인 용어에 맞춰 변경 |
-| `StudyInfoDTO` | `CardStateDTO` | `CardState`의 직렬화 버전 |
-| `UserCardDTO` | `CardDetailDTO` | `CardDetail`의 직렬화 버전. `UserCard` → `CardDetail` 리네이밍에 맞춤 |
+| `StudyInfoDTO` | 삭제 | Server Action은 도메인 타입 직접 반환, DTO 불필요 (RFC-0009) |
+| `UserCardDTO` | 삭제 | 동일 사유 (RFC-0009) |
 
 ### D. 프로퍼티 리네이밍
 

--- a/docs/decisions/0009-server-action-api-design.md
+++ b/docs/decisions/0009-server-action-api-design.md
@@ -133,18 +133,18 @@ export async function requireUserId(): Promise<string> {
 | 대상 | 파일 | 사유 |
 |------|------|------|
 | `StudyInfo` | `src/types/schemes.ts` | `CardState`로 리네이밍 (RFC-0006). ts-fsrs `Card`의 camelCase 래퍼로 유지 |
-| `StudyInfoDTO` | `src/types/schemes.ts` | `CardStateDTO`로 리네이밍. Server Action 직접 반환으로 전환 후 불필요하면 삭제 |
-| `UserCardDTO` | `src/types/schemes.ts` | `CardDetailDTO`로 리네이밍. 동일하게 불필요하면 삭제 |
+| `StudyInfoDTO` | `src/types/schemes.ts` | 삭제. Server Action은 도메인 타입을 직접 반환하므로 DTO 불필요 |
+| `UserCardDTO` | `src/types/schemes.ts` | 삭제. 동일 사유 |
 | `TokenDTO` | `src/types/schemes.ts` | JWT 인증 제거로 미사용 |
 | `SnakeToCamelCase` | `src/types/typeTransform.ts` | REST 변환용, 미사용 |
 | `toStudyInfo()` | `src/utils/converter.ts` | CardState 직접 매핑으로 불필요 |
 | `toUserCard()` | `src/utils/converter.ts` | CardDetail 직접 매핑으로 불필요 |
-| `toStudyInfoDTO()` | `src/utils/converter.ts` | CardStateDTO 리네이밍 후 불필요하면 삭제 |
+| `toStudyInfoDTO()` | `src/utils/converter.ts` | DTO 삭제로 불필요 |
 | `toKoreanCardDetail()` | `src/utils/converter.ts` | 더미 데이터 기반, 불필요 |
 | `STATE_MAP` | `src/constants/study.ts` | DTO state 문자열 변환용, 불필요 |
 | `STATE_MAP_REVERSE` | `src/constants/study.ts` | 동일 |
 | `DUMMY_KOR_CARD_DETAIL` | `src/utils/dummyData.ts` | `toKoreanCardDetail` 제거로 미사용 |
-| `DUMMY_STUDY_INFO_DTO` | `src/utils/dummyData.ts` | DTO 리네이밍/제거로 미사용 |
+| `DUMMY_STUDY_INFO_DTO` | `src/utils/dummyData.ts` | DTO 삭제로 미사용 |
 
 **StudyInfo → CardState 전략 (RFC-0006 참조):**
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,7 +33,7 @@ ts-fsrs 라이브러리의 **학습 상태**. 사용자별 가변 데이터.
 
 - due, stability, difficulty, scheduled_days, reps, lapses, state, last_review
 - state: 0=New, 1=Learning, 2=Review, 3=Relearning
-- `CardState`는 ts-fsrs `Card`의 camelCase 래퍼 타입. `CardStateDTO`는 직렬화 버전
+- `CardState`는 ts-fsrs `Card`의 camelCase 래퍼 타입. DTO는 Server Action 전환으로 삭제 (RFC-0009)
 - `CardDetail.state`로 접근
 - `schemes.ts`에서 정의. 다른 파일은 `import { CardState } from '@/types/schemes'`로 사용
 


### PR DESCRIPTION
## Summary
- Server Action API의 입출력 타입, 응답 구조, 인증 패턴, 캐시 키 규칙 설계
- RFC-0006 확정 용어 반영: StudyInfo → CardState 래퍼 유지, meaning → translation 통일
- 레거시 타입/유틸 정리 계획, Auth.js 스키마 정합성 수정 계획 포함

## Test plan
- [ ] RFC 내용 리뷰
- [ ] 구현 시 이 RFC 기준으로 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)