### PR TITLE
feat: 로그인 시 브라우저 정보 기반 user_options 자동 생성 (RFC-0010)

### DIFF
--- a/docs/decisions/0010-settings-guard-middleware.md
+++ b/docs/decisions/0010-settings-guard-middleware.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-최초 로그인 시 브라우저에서 `utcOffset`과 `locale`을 자동 수집하여 `user_options` 행을 생성한다. 이전 Spring Boot 서버에서 사용하던 "설정 없으면 settings 페이지로 리다이렉트" 방식을 대체한다.
+최초 로그인 시 브라우저에서 `utcOffset`을 자동 수집하고, URL path의 `locale`과 함께 `user_options` 행을 생성한다. `has-options` 쿠키로 초기화 완료 여부를 캐싱하여 이후 요청에서 DB 조회를 방지한다. 이전 Spring Boot 서버에서 사용하던 "설정 없으면 settings 페이지로 리다이렉트" 방식을 대체한다.
 
 ## Context
 
@@ -19,67 +19,72 @@
 
 - Google OAuth 로그인 성공 시 세션은 생기지만, `user_options` 테이블에 행이 없다
 - `getUserOption()`은 행이 없으면 하드코딩된 기본값(`utcOffset: 0`, `languageCode: 'en'`)을 반환한다
-- `utcOffset`이 맞지 않으면 학습 날짜 기준이 틀어지고, `languageCode`가 다르면 UI 언어가 잘못 표시된다
+- `utcOffset`이 맞지 않으면 학습 날짜 기준이 틀어진다
 
-그런데 `utcOffset`과 `locale`은 **브라우저가 이미 알고 있는 정보**다:
-
-- `new Date().getTimezoneOffset()` → UTC 오프셋 (분 단위)
-- `navigator.language` → 브라우저 locale (예: `ko`, `en`, `ja`)
-
-사용자에게 직접 입력을 요구할 필요 없이, 로그인 시점에 자동 수집하면 된다.
+`utcOffset`은 브라우저의 `new Date().getTimezoneOffset()`으로 수집 가능하고, `locale`은 이미 URL path의 `[locale]`에 있다.
 
 ## Decision
 
-로그인 직후 브라우저 정보를 수집하여 `user_options` 행을 자동 생성한다.
-
 ### 1. 수집 대상
 
-| 값 | 브라우저 API | 변환 |
+| 값 | 출처 | 변환 |
 |---|---|---|
-| `utcOffset` | `new Date().getTimezoneOffset()` | 분 단위 → 시간 단위 (부호 반전: `-540` → `9`) |
-| `languageCode` | `navigator.language` | `ko-KR` → `ko` (앱에서 지원하는 locale만 필터) |
+| `utcOffset` | `new Date().getTimezoneOffset()` (브라우저) | 분 단위 → 시간 단위 (부호 반전: `-540` → `9`) |
+| `languageCode` | URL path `[locale]` (서버) | 변환 불필요 |
 
 ### 2. 흐름
 
 ```
 1. 사용자가 /login 페이지에서 Google 로그인 버튼 클릭
 2. OAuth 완료 → Auth.js 세션 생성 → 리다이렉트
-3. 리다이렉트 대상 페이지(또는 공통 레이아웃)에서 클라이언트 훅 실행:
-   a. getUserOption() 호출하여 기존 설정 존재 여부 확인
-   b. 설정이 이미 있으면 → 아무것도 안 함
-   c. 설정이 없으면 → 브라우저에서 utcOffset, locale 수집 → postUserOption() 호출
-4. 이후 학습 페이지 정상 사용
+3. 서버(locale layout)에서 has-options 쿠키 확인
+   a. 쿠키 있음 → 통과 (DB 조회 없음)
+   b. 쿠키 없음 + 로그인 상태 → UserOptionInitializer 클라이언트 컴포넌트 렌더링
+4. 클라이언트에서 utcOffset 수집 → initUserOption(locale, utcOffset) 서버 액션 호출
+5. 서버 액션에서:
+   a. hasUserOption() → 이미 있으면 생성 스킵
+   b. 없으면 → postUserOption()으로 생성
+   c. has-options 쿠키 세팅
+6. 이후 요청에서는 쿠키가 있으므로 3a에서 통과
 ```
 
 ### 3. 기존 설정 존재 여부 판별
 
 현재 `getUserOption()`은 행이 없어도 기본값을 반환하므로 구분이 불가하다. 다음과 같이 변경한다:
 
-- `getUserOption()`: 행이 없으면 **에러를 throw**한다. 자동 생성 로직이 있으므로, 정상 흐름에서 행이 없는 상황은 발생하지 않아야 한다. 행이 없다면 훅 실행 실패 등 비정상 상태를 의미한다.
-- `hasUserOption(): Promise<boolean>`: 별도 추가. 클라이언트 훅(`useInitUserOption`)에서 설정 존재 여부를 확인하는 용도로 사용한다.
+- `getUserOption()`: 행이 없으면 **에러를 throw**한다. 자동 생성 로직이 있으므로, 정상 흐름에서 행이 없는 상황은 발생하지 않아야 한다.
+- `hasUserOption(): Promise<boolean>`: 별도 추가. `initUserOption` 서버 액션에서 설정이 없으면 생성한다.
+- `initUserOption(locale, utcOffset)`: 신규. `hasUserOption()` 확인 → 없으면 생성 → `has-options` 쿠키 세팅.
 
 ### 4. `dailyReviewWords`, `dailyStudyWords`는?
 
 이 두 값은 브라우저에서 자동 수집할 수 없다. 서버 측 기본값(`20`, `10`)을 그대로 사용한다. 사용자가 나중에 settings 페이지에서 변경할 수 있다.
 
-### 5. 변경 대상 파일
+### 5. 쿠키 생명주기
 
-- `src/api/option.ts` — `getUserOption()`에서 행 없을 시 에러 throw, `hasUserOption()` 추가
-- 신규 클라이언트 훅 (예: `src/hooks/useInitUserOption.ts`) — 브라우저 정보 수집 + 초기 설정 생성
-- 공통 레이아웃 또는 적절한 위치에 훅 배치
-- `src/app/[locale]/settings/page.tsx` — `getUserOption()`이 `null`을 반환하는 경우 처리
+| 시점 | 동작 |
+|------|------|
+| `initUserOption` 실행 | `has-options=1` 쿠키 세팅 |
+| 로그아웃 (`signOutAction`) | `has-options` 쿠키 삭제 |
+
+### 6. 변경 대상 파일
+
+- `src/api/option.ts` — `getUserOption()` 에러 throw, `hasUserOption()` 추가, `initUserOption()` 추가
+- `src/hooks/useInitUserOption.ts` — 브라우저 utcOffset 수집 + `initUserOption()` 호출
+- `src/components/UserOptionInitializer.tsx` — 훅을 감싸는 클라이언트 컴포넌트 (locale prop)
+- `src/app/[locale]/layout.tsx` — 쿠키 확인 후 조건부 `UserOptionInitializer` 렌더링
+- `src/api/auth-actions.ts` — 로그아웃 시 `has-options` 쿠키 삭제
 
 ## Alternatives Considered
 
 ### 미들웨어에서 settings 페이지로 리다이렉트 (이전 Spring Boot 방식)
 
-`has-settings` 쿠키를 도입하고, 설정이 없는 사용자를 middleware에서 `/settings`로 강제 리다이렉트하는 방식.
+설정이 없는 사용자를 middleware에서 `/settings`로 강제 리다이렉트하는 방식.
 
 **장점**: 설정 완료를 강제할 수 있다.
 
 **기각 사유**:
-- `utcOffset`과 `locale`은 브라우저가 이미 알고 있는 값이므로, 사용자에게 수동 입력을 요구하는 것은 불필요한 마찰이다
-- 쿠키와 DB 간 동기화 관리가 필요하다 (세팅/삭제/만료 등)
+- `utcOffset`은 브라우저가 이미 알고 있는 값이므로, 사용자에게 수동 입력을 요구하는 것은 불필요한 마찰이다
 - middleware의 분기 복잡도가 증가한다
 
 ### Auth.js signIn 콜백에서 직접 생성
@@ -89,29 +94,37 @@
 **장점**: 클라이언트 훅 없이 서버에서 완결된다.
 
 **기각 사유**:
-- Auth.js 콜백은 서버에서 실행되므로 브라우저의 `timezone`과 `navigator.language`에 접근할 수 없다
-- HTTP 헤더(`Accept-Language`, `CF-Timezone`)로 추정할 수는 있지만 정확도가 떨어진다
+- Auth.js 콜백은 서버에서 실행되므로 브라우저의 `timezone`에 접근할 수 없다
+- HTTP 헤더(`CF-Timezone`)로 추정할 수는 있지만 정확도가 떨어진다
+
+### 서버 layout에서 매 요청마다 DB 조회
+
+쿠키 없이 layout에서 `hasUserOption()`을 직접 호출하는 방식.
+
+**장점**: 쿠키 관리가 불필요하다.
+
+**기각 사유**:
+- 모든 로그인 사용자의 모든 페이지 요청에서 DB 쿼리 1회가 추가된다
+- 설정은 한 번 생성하면 거의 변하지 않으므로, 매번 조회하는 것은 과도하다
 
 ## Consequences
 
 ### Positive
 
 - 최초 로그인 사용자가 설정 페이지를 거치지 않아도 올바른 `utcOffset`과 `languageCode`로 즉시 학습을 시작할 수 있다
+- 쿠키 기반이므로 이후 요청에서 DB 조회가 발생하지 않는다
 - middleware 복잡도가 증가하지 않는다
-- 쿠키-DB 동기화 같은 추가 상태 관리가 불필요하다
 
 ### Negative
 
-- 브라우저 정보 기반이므로 100% 정확하지 않을 수 있다 (예: VPN 사용, 브라우저 언어 설정이 실제와 다른 경우). 하지만 사용자가 settings 페이지에서 언제든 수정 가능하므로 치명적이지 않다
+- 브라우저 `utcOffset`이 100% 정확하지 않을 수 있다 (예: VPN 사용). 사용자가 settings 페이지에서 수정 가능하므로 치명적이지 않다
 - `getUserOption()`이 행이 없으면 에러를 throw하므로, 기존 호출부에서 에러 처리가 필요하다
-- 클라이언트 훅이 실행되기 전 짧은 순간에는 설정이 없는 상태가 존재한다 (로딩 상태 처리 필요)
+- 쿠키가 삭제/만료되면 `initUserOption` 서버 액션이 한 번 더 호출되지만, 이미 설정이 있으면 생성을 스킵하고 쿠키만 재세팅한다
 
 ## References
 
 - RFC-0005: Auth.js + D1 + Google OAuth
 - RFC-0008: Server Actions + 직접 DB 접근
-- `src/api/option.ts` — `getUserOption`, `postUserOption`
+- `src/api/option.ts` — `getUserOption`, `postUserOption`, `initUserOption`
 - `src/db/schema.ts:108` — `user_options` 테이블 스키마
-- `src/app/[locale]/settings/page.tsx` — 현재 설정 페이지
 - MDN: [`Date.getTimezoneOffset()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset)
-- MDN: [`navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)

--- a/src/api/auth-actions.ts
+++ b/src/api/auth-actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { getAuth } from '@/auth';
+import { cookies } from 'next/headers';
 
 export async function signInWithGoogle() {
   const { signIn } = await getAuth();
@@ -10,6 +11,7 @@ export async function signInWithGoogle() {
 }
 
 export async function signOutAction() {
+  (await cookies()).delete('has-options');
   const { signOut } = await getAuth();
   const url = await signOut({ redirect: false });
   redirect(url);

--- a/src/api/option.ts
+++ b/src/api/option.ts
@@ -5,6 +5,8 @@ import { getDb } from '@/db';
 import { userOptions } from '@/db/schema';
 import { eq, sql } from 'drizzle-orm';
 import { getAuth } from '@/auth';
+import { cookies } from 'next/headers';
+import { Locale } from '@/types/Locale';
 
 async function getUserId(): Promise<string | null> {
   const { auth } = await getAuth();
@@ -78,4 +80,23 @@ export const postUserOption = async (userOption: UserOption): Promise<UserOption
     .run();
 
   return getUserOption();
+};
+
+export const initUserOption = async (languageCode: Locale, utcOffset: number): Promise<void> => {
+  const exists = await hasUserOption();
+
+  if (!exists) {
+    await postUserOption({
+      languageCode,
+      utcOffset,
+      dailyReviewWords: 20,
+      dailyStudyWords: 10,
+    });
+  }
+
+  (await cookies()).set('has-options', '1', {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+  });
 };

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,13 +8,18 @@ import ErrorBoundaryWrapper from '@/providers/ErrorBoundaryWrapper';
 
 import { getAuth } from '@/auth';
 import UserOptionInitializer from '@/components/UserOptionInitializer';
+import { cookies } from 'next/headers';
 
 import styles from './layout.module.scss';
 
-const NavigationLayout = async ({ children }: { children: React.ReactNode }) => {
+const NavigationLayout = async ({ children, params }: { children: React.ReactNode; params: Promise<{ locale: string }> }) => {
   const { auth } = await getAuth();
   const session = await auth();
   const isLoggedIn = !!session;
+  const { locale } = await params;
+
+  const hasOptionsCookie = (await cookies()).has('has-options');
+  const needsOptionInit = isLoggedIn && !hasOptionsCookie;
 
   return (
     <ErrorBoundaryWrapper>
@@ -24,7 +29,7 @@ const NavigationLayout = async ({ children }: { children: React.ReactNode }) => 
             <I18nProvider>
               <SnackbarProvider>
                 <Navigation isLoggedIn={isLoggedIn} />
-                {isLoggedIn && <UserOptionInitializer />}
+                {needsOptionInit && <UserOptionInitializer locale={locale} />}
                 {children}
               </SnackbarProvider>
             </I18nProvider>

--- a/src/components/UserOptionInitializer.tsx
+++ b/src/components/UserOptionInitializer.tsx
@@ -2,7 +2,7 @@
 
 import { useInitUserOption } from '@/hooks/useInitUserOption';
 
-export default function UserOptionInitializer() {
-  useInitUserOption();
+export default function UserOptionInitializer({ locale }: { locale: string }) {
+  useInitUserOption(locale);
   return null;
 }

--- a/src/hooks/useInitUserOption.ts
+++ b/src/hooks/useInitUserOption.ts
@@ -1,44 +1,20 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { hasUserOption, postUserOption } from '@/api/option';
+import { initUserOption } from '@/api/option';
 import { Locale } from '@/types/Locale';
-
-const SUPPORTED_LOCALES: Locale[] = [
-  'ar', 'en', 'es', 'fr', 'id', 'ja', 'ko', 'mn', 'ru', 'th', 'vi', 'zh',
-];
 
 function detectUtcOffset(): number {
   return -(new Date().getTimezoneOffset() / 60);
 }
 
-function detectLocale(): Locale {
-  const browserLang = navigator.language.split('-')[0];
-  if (SUPPORTED_LOCALES.includes(browserLang as Locale)) {
-    return browserLang as Locale;
-  }
-  return 'en';
-}
-
-export function useInitUserOption() {
+export function useInitUserOption(locale: string) {
   const initialized = useRef(false);
 
   useEffect(() => {
     if (initialized.current) return;
     initialized.current = true;
 
-    const init = async () => {
-      const exists = await hasUserOption();
-      if (exists) return;
-
-      await postUserOption({
-        utcOffset: detectUtcOffset(),
-        languageCode: detectLocale(),
-        dailyReviewWords: 20,
-        dailyStudyWords: 10,
-      });
-    };
-
-    init().catch(console.error);
-  }, []);
+    initUserOption(locale as Locale, detectUtcOffset()).catch(console.error);
+  }, [locale]);
 }


### PR DESCRIPTION
## Summary

- 최초 로그인 사용자의 `utcOffset`과 `locale`을 브라우저에서 자동 수집하여 `user_options` 행을 생성
- `getUserOption()`은 행이 없으면 에러를 throw하도록 변경
- `hasUserOption()` 함수 추가로 설정 존재 여부 판별
- 이전 Spring Boot 서버의 settings 강제 리다이렉트 방식을 대체

## Test plan

- [ ] DB에서 `user_options` 행 삭제 후 로그인 → 브라우저 timezone/locale 기반 행 자동 생성 확인
- [ ] 이미 설정이 있는 사용자 로그인 → 기존 설정 유지, 덮어쓰지 않는지 확인
- [ ] settings 페이지에서 정상 조회/저장 동작 확인
- [ ] 비로그인 상태에서 보호된 페이지 접근 → /login 리다이렉트 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)